### PR TITLE
Added global conf to choose if value should be rounded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/
+.idea

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ void main() {
 
 ## Configuration
 
-- `digits` (default: `3`): The number of digits to appear after the decimal
+- `Numeral.digits` (default: `3`): The number of digits to show after the decimal
   point.
-- `builder` (default: `NumeralUnit.value`): The function to build the
+- `Numeral.rounded` (default: `false`): Whether the value should be rounded or not.
+- `Numeral.builder` (default: `NumeralUnit.value`): The function to build the
   suffix.
 
 ### Global configuration
@@ -39,6 +40,7 @@ void main() {
 import 'package:numeral/numeral.dart';
 
 Numeral.digits = 2;
+Numeral.rounded = false;
 Numeral.builder = (unit) => '<Your custom suffix>';
 
 ```


### PR DESCRIPTION
This fixes https://github.com/medz/numeral.dart/issues/16, now devs could set `Numeral.rounded = true | false` to indicate if the value should be rounded, by default `rounded = false`, I assumed this should be the default expected behavior.

Before:
```dart
1960.numeral(digits: 1); // -> 2K;
```

Now:
```dart
1960.numeral(digits: 1); // -> 1.9K;
```

And confs available:
```dart
Numeral.digits = 1;
Numeral.rounded = true;
1960.numeral(); // -> 2K;
Numeral.rounded = false;
1960.numeral(); // -> 1.9K;
```