### PR TITLE
feat: add Traditional Chinese language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added a built-in `zh_hant.dart` language path with Traditional Chinese
+  compact units, cardinal numbers, year numbers, and financial numerals.
+
 ## 4.0.0
 
 - Rebuilt the public API around reusable codec classes such as

--- a/README.md
+++ b/README.md
@@ -215,6 +215,25 @@ rmb.format(1000000); // 人民币壹佰万元整
 rmb.format(1234567.89); // 人民币壹佰贰拾叁万肆仟伍佰陆拾柒元捌角玖分
 ```
 
+Traditional Chinese is available from its own language path:
+
+```dart
+import 'package:numeral/zh_hant.dart' as zh_hant;
+
+final compact = zh_hant.compact(maxFractionDigits: 2);
+final words = zh_hant.cardinal();
+final year = zh_hant.year();
+final financial = zh_hant.financial();
+
+compact.format(1234567); // 123.46萬
+compact.parse('2億'); // 200000000
+words.format(1000000); // 一百萬
+words.parse('兩百萬'); // 2000000
+words.parse('一萬零十'); // 10010
+year.format(2026); // 二〇二六
+financial.format(1000000); // 壹佰萬
+```
+
 External packages can build the same style of language path by reusing
 `NumeralLanguage`, `NumeralUnitSet`, and `NumeralCodec`.
 

--- a/lib/zh_hant.dart
+++ b/lib/zh_hant.dart
@@ -1,0 +1,175 @@
+/// Traditional Chinese numerals language pack.
+library;
+
+import 'src/codec.dart';
+import 'src/codec/compact.dart';
+import 'src/language.dart';
+import 'src/rounding.dart';
+import 'src/unit.dart';
+import 'zh.dart' as zh;
+
+String _toTraditional(String input) {
+  return input
+      .replaceAll('负', '負')
+      .replaceAll('万', '萬')
+      .replaceAll('亿', '億')
+      .replaceAll('两', '兩')
+      .replaceAll('贰', '貳')
+      .replaceAll('叁', '參')
+      .replaceAll('陆', '陸');
+}
+
+String _toSimplified(String input) {
+  return input
+      .replaceAll('負', '负')
+      .replaceAll('萬', '万')
+      .replaceAll('億', '亿')
+      .replaceAll('兩', '两')
+      .replaceAll('貳', '贰')
+      .replaceAll('貮', '贰')
+      .replaceAll('參', '叁')
+      .replaceAll('参', '叁')
+      .replaceAll('陸', '陆');
+}
+
+/// Traditional Chinese numerals language pack.
+const zhHant = TraditionalChineseNumerals();
+
+/// Traditional Chinese compact units: `萬`, `億`, `兆`.
+const traditionalChineseCompactUnits = NumeralUnitSet([
+  NumeralUnit(1, ''),
+  NumeralUnit(10000, '萬', aliases: ['万']),
+  NumeralUnit(100000000, '億', aliases: ['亿']),
+  NumeralUnit(1000000000000, '兆'),
+]);
+
+/// Creates a Traditional Chinese compact number codec.
+CompactCodec compact({
+  String decimalSeparator = '.',
+  int minFractionDigits = 0,
+  int maxFractionDigits = 2,
+  bool trimTrailingZeros = true,
+  Rounding rounding = Rounding.halfUp,
+  bool compactOverflow = true,
+}) {
+  return zhHant.compact(
+    decimalSeparator: decimalSeparator,
+    minFractionDigits: minFractionDigits,
+    maxFractionDigits: maxFractionDigits,
+    trimTrailingZeros: trimTrailingZeros,
+    rounding: rounding,
+    compactOverflow: compactOverflow,
+  );
+}
+
+/// Creates a Traditional Chinese cardinal number codec.
+TraditionalChineseCardinalCodec cardinal() => zhHant.cardinal();
+
+/// Creates a Traditional Chinese year number codec.
+TraditionalChineseYearCodec year({String suffix = ''}) {
+  return zhHant.year(suffix: suffix);
+}
+
+/// Creates a Traditional Chinese financial numeral codec.
+TraditionalChineseFinancialCodec financial() => zhHant.financial();
+
+/// Traditional Chinese numerals language pack.
+final class TraditionalChineseNumerals implements NumeralLanguage {
+  /// Creates a Traditional Chinese numerals language pack.
+  const TraditionalChineseNumerals();
+
+  @override
+  String get locale => 'zh-Hant';
+
+  @override
+  NumeralUnitSet get compactUnits => traditionalChineseCompactUnits;
+
+  @override
+  CompactCodec compact({
+    String decimalSeparator = '.',
+    int minFractionDigits = 0,
+    int maxFractionDigits = 2,
+    bool trimTrailingZeros = true,
+    Rounding rounding = Rounding.halfUp,
+    bool compactOverflow = true,
+  }) {
+    return CompactCodec(
+      unitSet: compactUnits,
+      decimalSeparator: decimalSeparator,
+      minFractionDigits: minFractionDigits,
+      maxFractionDigits: maxFractionDigits,
+      trimTrailingZeros: trimTrailingZeros,
+      rounding: rounding,
+      compactOverflow: compactOverflow,
+    );
+  }
+
+  /// Creates a Traditional Chinese cardinal number codec.
+  TraditionalChineseCardinalCodec cardinal() {
+    return const TraditionalChineseCardinalCodec();
+  }
+
+  /// Creates a Traditional Chinese year number codec.
+  TraditionalChineseYearCodec year({String suffix = ''}) {
+    return TraditionalChineseYearCodec(suffix: suffix);
+  }
+
+  /// Creates a Traditional Chinese financial numeral codec.
+  TraditionalChineseFinancialCodec financial() {
+    return const TraditionalChineseFinancialCodec();
+  }
+}
+
+/// Converts integers to and from Traditional Chinese cardinal numerals.
+///
+/// Formatting emits normalized Traditional Chinese text. Parsing also accepts
+/// common Simplified Chinese characters and `兩` variants.
+final class TraditionalChineseCardinalCodec extends NumeralCodec<int> {
+  /// Creates a Traditional Chinese cardinal codec.
+  const TraditionalChineseCardinalCodec();
+
+  static const _delegate = zh.ChineseCardinalCodec();
+
+  @override
+  String format(num value) => _toTraditional(_delegate.format(value));
+
+  @override
+  int parse(String input) => _delegate.parse(_toSimplified(input));
+}
+
+/// Converts years to and from Traditional Chinese digit-by-digit numerals.
+final class TraditionalChineseYearCodec extends NumeralCodec<int> {
+  /// Creates a Traditional Chinese year number codec.
+  const TraditionalChineseYearCodec({this.suffix = ''});
+
+  /// Text appended after the formatted year, such as `年`.
+  final String suffix;
+
+  @override
+  String format(num value) {
+    return zh.ChineseYearCodec(suffix: suffix).format(value);
+  }
+
+  @override
+  int parse(String input) {
+    final normalized = input.replaceAll('兩', '两');
+    return zh.ChineseYearCodec(suffix: suffix).parse(normalized);
+  }
+}
+
+/// Converts integers to and from Traditional Chinese financial numerals.
+///
+/// Formatting emits `貳`, `參`, `陸`, `萬`, and `億`. Parsing also accepts
+/// Simplified Chinese financial variants.
+final class TraditionalChineseFinancialCodec extends NumeralCodec<int> {
+  /// Creates a Traditional Chinese financial numeral codec.
+  const TraditionalChineseFinancialCodec();
+
+  static const _delegate = zh.ChineseFinancialCodec();
+
+  @override
+  String format(num value) => _toTraditional(_delegate.format(value));
+
+  @override
+  int parse(String input) => _delegate.parse(_toSimplified(input));
+}

--- a/test/zh_hant_test.dart
+++ b/test/zh_hant_test.dart
@@ -1,0 +1,158 @@
+import 'package:numeral/numeral.dart';
+import 'package:numeral/zh_hant.dart' as zh_hant;
+import 'package:test/test.dart';
+
+void main() {
+  group('Traditional Chinese language path', () {
+    test('exposes a Traditional Chinese language object', () {
+      expect(zh_hant.zhHant, isA<NumeralLanguage>());
+      expect(zh_hant.zhHant.locale, 'zh-Hant');
+      expect(
+        zh_hant.zhHant.compactUnits,
+        same(zh_hant.traditionalChineseCompactUnits),
+      );
+    });
+
+    test('formats and parses Traditional Chinese compact numbers', () {
+      final codec = zh_hant.compact(maxFractionDigits: 2);
+
+      expect(codec.format(1234567), '123.46萬');
+      expect(codec.format(120000000), '1.2億');
+      expect(codec.format(1200000000000), '1.2兆');
+      expect(codec.parse('3.5萬'), 35000);
+      expect(codec.parse('3.5万'), 35000);
+      expect(codec.parse('2億'), 200000000);
+      expect(codec.parse('2亿'), 200000000);
+    });
+
+    test('formats canonical cardinal numbers', () {
+      final codec = zh_hant.cardinal();
+
+      final cases = {
+        0: '零',
+        2: '二',
+        10: '十',
+        11: '十一',
+        20: '二十',
+        21: '二十一',
+        101: '一百零一',
+        110: '一百一十',
+        1020: '一千零二十',
+        10001: '一萬零一',
+        10010: '一萬零一十',
+        10021: '一萬零二十一',
+        2000000: '二百萬',
+        20000000: '二千萬',
+        200000000: '二億',
+        220000000: '二億二千萬',
+        10000000000000000: '一京',
+        1234567: '一百二十三萬四千五百六十七',
+        123456789: '一億二千三百四十五萬六千七百八十九',
+        -10021: '負一萬零二十一',
+      };
+
+      for (final entry in cases.entries) {
+        expect(codec.format(entry.key), entry.value, reason: '${entry.key}');
+      }
+    });
+
+    test('parses cardinal numbers and common variants', () {
+      final codec = zh_hant.cardinal();
+
+      final cases = {
+        '一百萬': 1000000,
+        '一百万': 1000000,
+        '二百萬': 2000000,
+        '兩百萬': 2000000,
+        '两百万': 2000000,
+        '二千萬': 20000000,
+        '兩千萬': 20000000,
+        '二億': 200000000,
+        '兩億': 200000000,
+        '一百二': 120,
+        '兩百五': 250,
+        '一千二': 1200,
+        '一萬二': 12000,
+        '一萬二千三': 12300,
+        '一萬零一十': 10010,
+        '一萬零十': 10010,
+        '一萬零二': 10002,
+        '一萬零二十一': 10021,
+        '二億兩千萬': 220000000,
+        '兩億兩千萬': 220000000,
+        '一億二': 120000000,
+        '一百二十三萬四千五百六十七': 1234567,
+        '負兩百萬': -2000000,
+      };
+
+      for (final entry in cases.entries) {
+        expect(codec.parse(entry.key), entry.value, reason: entry.key);
+      }
+    });
+
+    test('rejects malformed cardinal numbers', () {
+      final codec = zh_hant.cardinal();
+
+      expect(codec.tryParse('not a number'), isNull);
+      expect(codec.tryParse('一二'), isNull);
+      expect(codec.tryParse('一百零'), isNull);
+      expect(codec.tryParse('零一'), isNull);
+      expect(codec.tryParse('兩十'), isNull);
+      expect(codec.tryParse('一萬零兩十'), isNull);
+      expect(codec.tryParse('萬'), isNull);
+    });
+
+    test('formats and parses year numbers digit by digit', () {
+      final codec = zh_hant.year();
+      final yearWithSuffix = zh_hant.year(suffix: '年');
+
+      expect(codec.format(2025), '二〇二五');
+      expect(codec.format(2026), '二〇二六');
+      expect(yearWithSuffix.format(2026), '二〇二六年');
+      expect(codec.parse('二〇二六'), 2026);
+      expect(codec.parse('二零二六年'), 2026);
+      expect(yearWithSuffix.parse('二〇二六年'), 2026);
+      expect(yearWithSuffix.tryParse('二〇二六'), isNull);
+      expect(codec.tryParse('二千零二十六'), isNull);
+      expect(() => codec.format(1e20), throwsA(isA<ArgumentError>()));
+    });
+
+    test('formats and parses financial numerals', () {
+      final codec = zh_hant.financial();
+
+      expect(codec.format(0), '零');
+      expect(codec.format(10), '壹拾');
+      expect(codec.format(101), '壹佰零壹');
+      expect(codec.format(10001), '壹萬零壹');
+      expect(codec.format(10010), '壹萬零壹拾');
+      expect(codec.format(100000), '壹拾萬');
+      expect(codec.format(1000000), '壹佰萬');
+      expect(codec.format(1234567), '壹佰貳拾參萬肆仟伍佰陸拾柒');
+
+      expect(codec.parse('壹拾萬'), 100000);
+      expect(codec.parse('壹佰萬'), 1000000);
+      expect(codec.parse('壹佰万'), 1000000);
+      expect(codec.parse('壹佰零貳'), 102);
+      expect(codec.parse('壹佰零贰'), 102);
+      expect(codec.parse('壹萬零壹拾'), 10010);
+      expect(codec.parse('壹佰貳拾參萬肆仟伍佰陸拾柒'), 1234567);
+      expect(codec.parse('壹佰贰拾叁万肆仟伍佰陆拾柒'), 1234567);
+      expect(codec.tryParse('拾'), isNull);
+      expect(codec.tryParse('壹佰零拾'), isNull);
+      expect(codec.tryParse('壹萬零拾'), isNull);
+      expect(codec.tryParse('一百萬'), isNull);
+      expect(codec.tryParse('壹貳'), isNull);
+      expect(codec.tryParse('萬'), isNull);
+    });
+
+    test('language object creates localized codecs', () {
+      expect(
+        zh_hant.zhHant.compact(maxFractionDigits: 0).format(1000000),
+        '100萬',
+      );
+      expect(zh_hant.zhHant.cardinal().format(1000000), '一百萬');
+      expect(zh_hant.zhHant.year().format(2026), '二〇二六');
+      expect(zh_hant.zhHant.financial().format(1000000), '壹佰萬');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `package:numeral/zh_hant.dart` as a built-in Traditional Chinese language path.
- Add Traditional Chinese compact units for `萬`, `億`, and `兆` with Simplified aliases for parsing.
- Add Traditional Chinese cardinal, year, and financial numeral codecs.
- Document the new language path and add an Unreleased changelog entry.

## Validation
- `dart format lib/zh_hant.dart test/zh_hant_test.dart`
- `dart analyze`
- `dart test`
- `dart test test/zh_hant_test.dart`
- `dart pub publish --dry-run` (0 warnings)

## References
- Traditional Chinese ordinary and financial numeral forms: https://zh.wikipedia.org/zh-hant/%E6%B1%89%E5%AD%97%E6%95%B0%E5%AD%97
- Traditional financial amount characters such as `壹、貳、參、肆、伍、陸、柒、捌、玖、拾、佰、仟、萬、億`: https://rr78.com/Digital-Case-Conversion/

Issue: N/A
