### PR TITLE
ci: run Dart tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Dart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: dart analyze
+
+      - name: Run tests
+        run: dart test


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for Dart CI.
- Run on pull requests to `main`, pushes to `main`, and manual dispatch.
- Install dependencies, check formatting, analyze, and run the test suite.

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart pub publish --dry-run` (0 warnings)

Issue: N/A
