### PR TITLE
feat: add Korean language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added a built-in `ko.dart` language path with Korean compact units,
+  Sino-Korean cardinal numbers, and year numbers.
+
 ## 4.0.0
 
 - Rebuilt the public API around reusable codec classes such as

--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ rmb.format(1000000); // 人民币壹佰万元整
 rmb.format(1234567.89); // 人民币壹佰贰拾叁万肆仟伍佰陆拾柒元捌角玖分
 ```
 
+Korean is available from its own language path:
+
+```dart
+import 'package:numeral/ko.dart' as ko;
+
+final compact = ko.compact(maxFractionDigits: 2);
+final words = ko.cardinal();
+final year = ko.year();
+
+compact.format(12345); // 1.23만
+compact.parse('2억'); // 200000000
+words.format(1000000); // 백만
+words.format(123456789); // 일억이천삼백사십오만육천칠백팔십구
+words.parse('일억 이천만'); // 120000000
+year.format(2026); // 이천이십육
+```
+
 External packages can build the same style of language path by reusing
 `NumeralLanguage`, `NumeralUnitSet`, and `NumeralCodec`.
 

--- a/lib/ko.dart
+++ b/lib/ko.dart
@@ -29,6 +29,7 @@ const ko = KoreanNumerals();
 /// Korean compact units: `만`, `억`, `조`.
 const koreanCompactUnits = NumeralUnitSet([
   NumeralUnit(1, ''),
+  NumeralUnit(1000, '천', aliases: ['千']),
   NumeralUnit(10000, '만', aliases: ['萬', '万']),
   NumeralUnit(100000000, '억', aliases: ['億']),
   NumeralUnit(1000000000000, '조', aliases: ['兆']),
@@ -247,8 +248,13 @@ final class KoreanCardinalCodec extends NumeralCodec<int> {
         throw FormatException('Unexpected Korean cardinal token.', input);
       }
 
+      final rawSection = sectionText.toString();
+      if (rawSection.isEmpty && total > 0) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+
       final section = _parseSection(
-        sectionText.toString(),
+        rawSection,
         input,
         allowEmptyAsOne: true,
         allowLeadingZero: false,

--- a/lib/ko.dart
+++ b/lib/ko.dart
@@ -200,7 +200,8 @@ final class KoreanCardinalCodec extends NumeralCodec<int> {
       final section = sections[index];
       if (section == 0) continue;
 
-      final omitOneBeforeSectionUnit = index == 1 && section == 1;
+      final omitOneBeforeSectionUnit =
+          buffer.isEmpty && index == 1 && section == 1;
       if (!omitOneBeforeSectionUnit) {
         buffer.write(_formatSection(section));
       }
@@ -344,6 +345,7 @@ final class KoreanCardinalCodec extends NumeralCodec<int> {
         throw FormatException('Unexpected Korean cardinal token.', input);
       }
       if (unit >= lastUnit ||
+          (zeroPending && unitBeforeZero ~/ 10 == unit) ||
           (zeroPending && (!allowLeadingZero || section > 0 || sawUnit))) {
         throw FormatException('Unexpected Korean cardinal token.', input);
       }

--- a/lib/ko.dart
+++ b/lib/ko.dart
@@ -1,0 +1,428 @@
+/// Korean numerals language pack.
+library;
+
+import 'src/codec.dart';
+import 'src/codec/compact.dart';
+import 'src/language.dart';
+import 'src/rounding.dart';
+import 'src/unit.dart';
+
+int _checkedInteger(num value, String message) {
+  if (!value.isFinite || value % 1 != 0) {
+    throw ArgumentError.value(value, 'value', message);
+  }
+
+  final integer = value.toInt();
+  if (value is double && integer.toDouble() != value) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Must be exactly representable as an integer.',
+    );
+  }
+  return integer;
+}
+
+/// Korean numerals language pack.
+const ko = KoreanNumerals();
+
+/// Korean compact units: `만`, `억`, `조`.
+const koreanCompactUnits = NumeralUnitSet([
+  NumeralUnit(1, ''),
+  NumeralUnit(10000, '만', aliases: ['萬', '万']),
+  NumeralUnit(100000000, '억', aliases: ['億']),
+  NumeralUnit(1000000000000, '조', aliases: ['兆']),
+]);
+
+/// Creates a Korean compact number codec.
+CompactCodec compact({
+  String decimalSeparator = '.',
+  int minFractionDigits = 0,
+  int maxFractionDigits = 2,
+  bool trimTrailingZeros = true,
+  Rounding rounding = Rounding.halfUp,
+  bool compactOverflow = true,
+}) {
+  return ko.compact(
+    decimalSeparator: decimalSeparator,
+    minFractionDigits: minFractionDigits,
+    maxFractionDigits: maxFractionDigits,
+    trimTrailingZeros: trimTrailingZeros,
+    rounding: rounding,
+    compactOverflow: compactOverflow,
+  );
+}
+
+/// Creates a Sino-Korean cardinal number codec.
+KoreanCardinalCodec cardinal() => ko.cardinal();
+
+/// Creates a Korean year number codec.
+KoreanYearCodec year({String suffix = ''}) => ko.year(suffix: suffix);
+
+/// Korean numerals language pack.
+final class KoreanNumerals implements NumeralLanguage {
+  /// Creates a Korean numerals language pack.
+  const KoreanNumerals();
+
+  @override
+  String get locale => 'ko';
+
+  @override
+  NumeralUnitSet get compactUnits => koreanCompactUnits;
+
+  @override
+  CompactCodec compact({
+    String decimalSeparator = '.',
+    int minFractionDigits = 0,
+    int maxFractionDigits = 2,
+    bool trimTrailingZeros = true,
+    Rounding rounding = Rounding.halfUp,
+    bool compactOverflow = true,
+  }) {
+    return CompactCodec(
+      unitSet: compactUnits,
+      decimalSeparator: decimalSeparator,
+      minFractionDigits: minFractionDigits,
+      maxFractionDigits: maxFractionDigits,
+      trimTrailingZeros: trimTrailingZeros,
+      rounding: rounding,
+      compactOverflow: compactOverflow,
+    );
+  }
+
+  /// Creates a Sino-Korean cardinal number codec.
+  KoreanCardinalCodec cardinal() => const KoreanCardinalCodec();
+
+  /// Creates a Korean year number codec.
+  KoreanYearCodec year({String suffix = ''}) => KoreanYearCodec(
+        suffix: suffix,
+      );
+}
+
+/// Converts integers to and from Sino-Korean cardinal numerals.
+///
+/// Formatting emits normalized Hangul text. Parsing also accepts common Hanja
+/// and financial Hanja variants.
+final class KoreanCardinalCodec extends NumeralCodec<int> {
+  /// Creates a Sino-Korean cardinal codec.
+  const KoreanCardinalCodec();
+
+  static const _digits = ['영', '일', '이', '삼', '사', '오', '육', '칠', '팔', '구'];
+  static const _smallUnits = ['', '십', '백', '천'];
+  static const _sectionUnits = ['', '만', '억', '조', '경'];
+  static const _smallScales = [1, 10, 100, 1000];
+  static const _digitValues = {
+    '영': 0,
+    '령': 0,
+    '공': 0,
+    '零': 0,
+    '空': 0,
+    '일': 1,
+    '一': 1,
+    '壹': 1,
+    '이': 2,
+    '二': 2,
+    '貳': 2,
+    '贰': 2,
+    '삼': 3,
+    '三': 3,
+    '參': 3,
+    '参': 3,
+    '叁': 3,
+    '사': 4,
+    '四': 4,
+    '肆': 4,
+    '오': 5,
+    '五': 5,
+    '伍': 5,
+    '육': 6,
+    '륙': 6,
+    '六': 6,
+    '陸': 6,
+    '陆': 6,
+    '칠': 7,
+    '七': 7,
+    '柒': 7,
+    '팔': 8,
+    '八': 8,
+    '捌': 8,
+    '구': 9,
+    '九': 9,
+    '玖': 9,
+  };
+  static const _smallUnitValues = {
+    '십': 10,
+    '十': 10,
+    '拾': 10,
+    '백': 100,
+    '百': 100,
+    '佰': 100,
+    '천': 1000,
+    '千': 1000,
+    '仟': 1000,
+    '阡': 1000,
+  };
+  static const _sectionUnitValues = {
+    '만': 10000,
+    '萬': 10000,
+    '万': 10000,
+    '억': 100000000,
+    '億': 100000000,
+    '조': 1000000000000,
+    '兆': 1000000000000,
+    '경': 10000000000000000,
+    '京': 10000000000000000,
+  };
+
+  @override
+  String format(num value) {
+    final integer = _checkedInteger(value, 'Must be a finite integer.');
+    if (integer == 0) return _digits[0];
+    if (integer < 0) return '마이너스${format(-integer)}';
+
+    final sections = <int>[];
+    var rest = integer;
+    while (rest > 0) {
+      sections.add(rest % 10000);
+      rest ~/= 10000;
+    }
+    if (sections.length > _sectionUnits.length) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Exceeds supported Korean section units.',
+      );
+    }
+
+    final buffer = StringBuffer();
+    for (var index = sections.length - 1; index >= 0; index -= 1) {
+      final section = sections[index];
+      if (section == 0) continue;
+
+      final omitOneBeforeSectionUnit = index == 1 && section == 1;
+      if (!omitOneBeforeSectionUnit) {
+        buffer.write(_formatSection(section));
+      }
+      buffer.write(_sectionUnits[index]);
+    }
+
+    return buffer.toString();
+  }
+
+  @override
+  int parse(String input) {
+    var text = input.trim().replaceAll(RegExp(r'\s+'), '');
+    if (text.isEmpty) {
+      throw FormatException('Expected a Korean cardinal number.', input);
+    }
+
+    var negative = false;
+    if (text.startsWith('마이너스')) {
+      negative = true;
+      text = text.substring('마이너스'.length);
+    } else if (text.startsWith('-')) {
+      negative = true;
+      text = text.substring(1);
+    }
+    if (text.isEmpty) {
+      throw FormatException('Expected a Korean cardinal number.', input);
+    }
+
+    if (text.runes.length == 1 &&
+        _digitValues[String.fromCharCode(text.runes.single)] == 0) {
+      return 0;
+    }
+
+    var total = 0;
+    var sectionText = StringBuffer();
+    var lastSectionUnit = 1000000000000000000;
+    for (final char in text.runes.map(String.fromCharCode)) {
+      final sectionUnit = _sectionUnitValues[char];
+      if (sectionUnit == null) {
+        sectionText.write(char);
+        continue;
+      }
+
+      if (sectionUnit >= lastSectionUnit) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+
+      final section = _parseSection(
+        sectionText.toString(),
+        input,
+        allowEmptyAsOne: true,
+        allowLeadingZero: false,
+      );
+      if (section == 0) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+
+      total += section * sectionUnit;
+      sectionText = StringBuffer();
+      lastSectionUnit = sectionUnit;
+    }
+
+    final lowerSection = _parseSection(
+      sectionText.toString(),
+      input,
+      allowEmptyAsOne: false,
+      allowLeadingZero: total > 0,
+    );
+    final value = total + lowerSection;
+    return negative ? -value : value;
+  }
+
+  String _formatSection(int section) {
+    final buffer = StringBuffer();
+
+    for (var position = 3; position >= 0; position -= 1) {
+      final scale = _smallScales[position];
+      final digit = section ~/ scale % 10;
+      if (digit == 0) continue;
+
+      final omitOne = digit == 1 && scale > 1;
+      if (!omitOne) buffer.write(_digits[digit]);
+      buffer.write(_smallUnits[position]);
+    }
+
+    return buffer.toString();
+  }
+
+  int _parseSection(
+    String text,
+    String input, {
+    required bool allowEmptyAsOne,
+    required bool allowLeadingZero,
+  }) {
+    if (text.isEmpty) return allowEmptyAsOne ? 1 : 0;
+
+    var section = 0;
+    int? pendingDigit;
+    var lastUnit = 10000;
+    var sawAny = false;
+    var sawUnit = false;
+    var zeroPending = false;
+    var unitBeforeZero = 10000;
+
+    for (final char in text.runes.map(String.fromCharCode)) {
+      final digit = _digitValues[char];
+      if (digit != null) {
+        if (digit == 0) {
+          if (pendingDigit != null) {
+            throw FormatException('Unexpected Korean cardinal token.', input);
+          }
+          if (!sawAny && !allowLeadingZero) {
+            throw FormatException('Unexpected Korean cardinal token.', input);
+          }
+          zeroPending = true;
+          unitBeforeZero = lastUnit;
+          sawAny = true;
+          continue;
+        }
+
+        if (pendingDigit != null) {
+          throw FormatException('Unexpected Korean cardinal token.', input);
+        }
+        if (zeroPending && unitBeforeZero <= 10) {
+          throw FormatException('Unexpected Korean cardinal token.', input);
+        }
+
+        pendingDigit = digit;
+        zeroPending = false;
+        sawAny = true;
+        continue;
+      }
+
+      final unit = _smallUnitValues[char];
+      if (unit == null) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+      if (unit >= lastUnit ||
+          (zeroPending && (!allowLeadingZero || section > 0 || sawUnit))) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+
+      final digitForUnit = pendingDigit ?? 1;
+      if (digitForUnit == 0) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+      section += digitForUnit * unit;
+      pendingDigit = null;
+      lastUnit = unit;
+      sawAny = true;
+      sawUnit = true;
+      zeroPending = false;
+    }
+
+    if (zeroPending) {
+      throw FormatException('Unexpected Korean cardinal token.', input);
+    }
+    if (pendingDigit != null) {
+      if (!sawUnit && section == 0 && _nonZeroDigitCount(text) > 1) {
+        throw FormatException('Unexpected Korean cardinal token.', input);
+      }
+      section += pendingDigit;
+    }
+
+    return section;
+  }
+
+  int _nonZeroDigitCount(String text) {
+    var count = 0;
+    for (final char in text.runes.map(String.fromCharCode)) {
+      final digit = _digitValues[char];
+      if (digit != null && digit != 0) count += 1;
+    }
+    return count;
+  }
+}
+
+/// Converts years to and from Sino-Korean year numerals.
+final class KoreanYearCodec extends NumeralCodec<int> {
+  /// Creates a Korean year number codec.
+  const KoreanYearCodec({this.suffix = ''});
+
+  /// Text appended after the formatted year, such as `년`.
+  final String suffix;
+
+  static const _cardinal = KoreanCardinalCodec();
+
+  @override
+  String format(num value) {
+    final integer = _checkedInteger(
+      value,
+      'Must be a non-negative finite integer.',
+    );
+    if (integer < 0) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Must be a non-negative finite integer.',
+      );
+    }
+
+    return '${_cardinal.format(integer)}$suffix';
+  }
+
+  @override
+  int parse(String input) {
+    var text = input.trim();
+    if (suffix.isNotEmpty) {
+      if (!text.endsWith(suffix)) {
+        throw FormatException('Expected year suffix "$suffix".', input);
+      }
+      text = text.substring(0, text.length - suffix.length);
+    } else if (text.endsWith('년')) {
+      text = text.substring(0, text.length - 1);
+    }
+
+    final value = _cardinal.parse(text);
+    if (value < 0) {
+      throw FormatException(
+        'Expected a non-negative Korean year number.',
+        input,
+      );
+    }
+    return value;
+  }
+}

--- a/test/ko_test.dart
+++ b/test/ko_test.dart
@@ -13,10 +13,15 @@ void main() {
     test('formats and parses Korean compact numbers', () {
       final codec = ko.compact(maxFractionDigits: 2);
 
+      expect(codec.format(1000), '1천');
+      expect(codec.format(1100), '1.1천');
       expect(codec.format(12345), '1.23만');
       expect(codec.format(1000000), '100만');
       expect(codec.format(120000000), '1.2억');
       expect(codec.format(1200000000000), '1.2조');
+      expect(codec.parse('1천'), 1000);
+      expect(codec.parse('1.1천'), 1100);
+      expect(codec.parse('1千'), 1000);
       expect(codec.parse('1.5만'), 15000);
       expect(codec.parse('2억'), 200000000);
       expect(codec.parse('3萬'), 30000);
@@ -109,6 +114,8 @@ void main() {
       expect(codec.tryParse('십영일'), isNull);
       expect(codec.tryParse('만영'), isNull);
       expect(codec.tryParse('만만'), isNull);
+      expect(codec.tryParse('억만'), isNull);
+      expect(codec.tryParse('일억만'), isNull);
       expect(codec.tryParse('백백'), isNull);
     });
 
@@ -133,7 +140,10 @@ void main() {
       expect(yearWithSuffix.parse('이천이십육년'), 2026);
       expect(yearWithSuffix.tryParse('이천이십육'), isNull);
       expect(codec.tryParse('마이너스일년'), isNull);
-      expect(() => codec.format(1e20), throwsA(isA<ArgumentError>()));
+      expect(
+        () => codec.format(double.maxFinite),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('language object creates localized codecs', () {

--- a/test/ko_test.dart
+++ b/test/ko_test.dart
@@ -1,0 +1,145 @@
+import 'package:numeral/ko.dart' as ko;
+import 'package:numeral/numeral.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Korean language path', () {
+    test('exposes a Korean language object', () {
+      expect(ko.ko, isA<NumeralLanguage>());
+      expect(ko.ko.locale, 'ko');
+      expect(ko.ko.compactUnits, same(ko.koreanCompactUnits));
+    });
+
+    test('formats and parses Korean compact numbers', () {
+      final codec = ko.compact(maxFractionDigits: 2);
+
+      expect(codec.format(12345), '1.23만');
+      expect(codec.format(1000000), '100만');
+      expect(codec.format(120000000), '1.2억');
+      expect(codec.format(1200000000000), '1.2조');
+      expect(codec.parse('1.5만'), 15000);
+      expect(codec.parse('2억'), 200000000);
+      expect(codec.parse('3萬'), 30000);
+      expect(codec.parse('1兆'), 1000000000000);
+    });
+
+    test('formats canonical Sino-Korean cardinal numbers', () {
+      final codec = ko.cardinal();
+
+      final cases = {
+        0: '영',
+        1: '일',
+        10: '십',
+        11: '십일',
+        20: '이십',
+        21: '이십일',
+        100: '백',
+        101: '백일',
+        110: '백십',
+        111: '백십일',
+        1000: '천',
+        1001: '천일',
+        1010: '천십',
+        1100: '천백',
+        1111: '천백십일',
+        10000: '만',
+        10001: '만일',
+        10010: '만십',
+        10100: '만백',
+        11000: '만천',
+        100000: '십만',
+        1000000: '백만',
+        10000000: '천만',
+        100000000: '일억',
+        200000000: '이억',
+        1000000000000: '일조',
+        10000000000000000: '일경',
+        123456789: '일억이천삼백사십오만육천칠백팔십구',
+        -10001: '마이너스만일',
+      };
+
+      for (final entry in cases.entries) {
+        expect(codec.format(entry.key), entry.value, reason: '${entry.key}');
+      }
+    });
+
+    test('parses cardinal numbers and common variants', () {
+      final codec = ko.cardinal();
+
+      final cases = {
+        '영': 0,
+        '공': 0,
+        '령': 0,
+        '십': 10,
+        '일십': 10,
+        '백': 100,
+        '일백': 100,
+        '천': 1000,
+        '일천': 1000,
+        '만': 10000,
+        '일만': 10000,
+        '만일': 10001,
+        '일만영일': 10001,
+        '만십': 10010,
+        '일만영십': 10010,
+        '백만': 1000000,
+        '일백만': 1000000,
+        '천만': 10000000,
+        '일천만': 10000000,
+        '일억': 100000000,
+        '일억 이천만': 120000000,
+        '이억이천만': 220000000,
+        '일억이천삼백사십오만육천칠백팔십구': 123456789,
+        '壹億貳仟參佰肆拾伍萬六千七百八十九': 123456789,
+        '마이너스백만': -1000000,
+        '-백만': -1000000,
+      };
+
+      for (final entry in cases.entries) {
+        expect(codec.parse(entry.key), entry.value, reason: entry.key);
+      }
+    });
+
+    test('rejects malformed cardinal numbers', () {
+      final codec = ko.cardinal();
+
+      expect(codec.tryParse('not a number'), isNull);
+      expect(codec.tryParse('일이'), isNull);
+      expect(codec.tryParse('영일'), isNull);
+      expect(codec.tryParse('십영일'), isNull);
+      expect(codec.tryParse('만영'), isNull);
+      expect(codec.tryParse('만만'), isNull);
+      expect(codec.tryParse('백백'), isNull);
+    });
+
+    test('rejects cardinal values beyond supported section units', () {
+      final codec = ko.cardinal();
+
+      expect(
+        () => codec.format(1e20),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('formats and parses year numbers with Sino-Korean readings', () {
+      final codec = ko.year();
+      final yearWithSuffix = ko.year(suffix: '년');
+
+      expect(codec.format(2025), '이천이십오');
+      expect(codec.format(2026), '이천이십육');
+      expect(yearWithSuffix.format(2026), '이천이십육년');
+      expect(codec.parse('이천이십육'), 2026);
+      expect(codec.parse('이천이십육년'), 2026);
+      expect(yearWithSuffix.parse('이천이십육년'), 2026);
+      expect(yearWithSuffix.tryParse('이천이십육'), isNull);
+      expect(codec.tryParse('마이너스일년'), isNull);
+      expect(() => codec.format(1e20), throwsA(isA<ArgumentError>()));
+    });
+
+    test('language object creates localized codecs', () {
+      expect(ko.ko.compact(maxFractionDigits: 0).format(1000000), '100만');
+      expect(ko.ko.cardinal().format(1000000), '백만');
+      expect(ko.ko.year().format(2026), '이천이십육');
+    });
+  });
+}

--- a/test/ko_test.dart
+++ b/test/ko_test.dart
@@ -56,6 +56,7 @@ void main() {
         1000000: '백만',
         10000000: '천만',
         100000000: '일억',
+        100010000: '일억일만',
         200000000: '이억',
         1000000000000: '일조',
         10000000000000000: '일경',
@@ -92,6 +93,7 @@ void main() {
         '천만': 10000000,
         '일천만': 10000000,
         '일억': 100000000,
+        '일억일만': 100010000,
         '일억 이천만': 120000000,
         '이억이천만': 220000000,
         '일억이천삼백사십오만육천칠백팔십구': 123456789,
@@ -112,6 +114,9 @@ void main() {
       expect(codec.tryParse('일이'), isNull);
       expect(codec.tryParse('영일'), isNull);
       expect(codec.tryParse('십영일'), isNull);
+      expect(codec.tryParse('백영십'), isNull);
+      expect(codec.tryParse('천영백'), isNull);
+      expect(codec.tryParse('일만영천'), isNull);
       expect(codec.tryParse('만영'), isNull);
       expect(codec.tryParse('만만'), isNull);
       expect(codec.tryParse('억만'), isNull);


### PR DESCRIPTION
## Summary
- Add `package:numeral/ko.dart` as a built-in Korean language path.
- Add Korean compact units for `만`, `억`, and `조` with Hanja aliases for parsing.
- Add Sino-Korean cardinal and year codecs with normalized Hangul formatting and lenient Hangul/Hanja parsing.
- Document the new language path and add an Unreleased changelog entry.

## Validation
- `dart format lib/ko.dart test/ko_test.dart`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart test test/ko_test.dart`
- `dart pub publish --dry-run` (0 warnings)

## References
- Unicode CLDR Korean compact number examples: https://unicode.org/cldr/charts/45/verify/numbers/ko.html
- Korean numeral systems and Sino-Korean usage: https://en.wikipedia.org/wiki/Korean_numerals

Issue: N/A
