### PR TITLE
docs: rewrite package descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Numeral
 
-Lightweight number formatting and parsing for Dart.
+Composable number formatting and parsing for Dart.
 
-Numeral focuses on the display formats that application code reaches for every
-day: decimals, compact numbers, percentages, byte sizes, and simple currency
-strings. Create a codec once, keep it in your app utilities, and use it for both
-formatting and parsing.
+Numeral turns application numbers into display strings and back again with
+reusable codecs for decimals, compact values, percentages, byte sizes, currency
+text, and locale-aware numerals. Create a codec once, keep it in your app
+utilities, and use the same object for both formatting and parsing.
 
 ## Installation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: numeral
 description: >-
-  Lightweight number formatting and parsing for decimals, compact numbers,
-  percentages, byte sizes, and currency display strings.
+  Composable number formatting and parsing for decimals, compact values,
+  percentages, byte sizes, currency display text, and locale-aware numerals.
 
 version: 4.0.0
 repository: https://github.com/medz/numeral.dart


### PR DESCRIPTION
## Summary

- Rewrite the README opening copy so the GitHub repository landing page explains Numeral as a composable formatting and parsing toolkit.
- Update the `pubspec.yaml` package description to match the current codec and language-pack API direction.

## Validation

- `dart pub publish --dry-run`

No linked issue; this is a copy-only description update.